### PR TITLE
Add iOS option for clear & read all

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Repository class to handle in-memory data
   chili_flutter_storage_impl:
     git:
       url: https://github.com/ChiliLabs/chili-flutter-storage-impl.git
-      ref: 0.0.3
+      ref: 0.0.4
 ```
 
 2. For shared preferences - create shared prefs instance in main.dart

--- a/lib/src/secure_key_value_storage.dart
+++ b/lib/src/secure_key_value_storage.dart
@@ -1,5 +1,5 @@
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:chili_flutter_storage/chili_flutter_storage.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 typedef ErrorCallback = void Function(Object ex, StackTrace st);
 
@@ -19,6 +19,9 @@ class SecureKeyValueStorage implements SecureStorage {
   });
 
   /// Get
+  IOSOptions? get _iosOptions =>
+      iOSTransferToCloud ? null : _iOSDisableCloudStoringOptions;
+
   @override
   Future<bool?> getBool(String key) async {
     final val = await _read(key);
@@ -78,7 +81,7 @@ class SecureKeyValueStorage implements SecureStorage {
     try {
       await _storage.delete(
         key: key,
-        iOptions: iOSTransferToCloud ? null : _iOSDisableCloudStoringOptions,
+        iOptions: _iosOptions,
       );
     } catch (ex, st) {
       onError(ex, st);
@@ -88,7 +91,9 @@ class SecureKeyValueStorage implements SecureStorage {
   @override
   Future<void> clearAll() async {
     try {
-      await _storage.deleteAll();
+      await _storage.deleteAll(
+        iOptions: _iosOptions,
+      );
     } catch (ex, st) {
       onError(ex, st);
     }
@@ -96,7 +101,9 @@ class SecureKeyValueStorage implements SecureStorage {
 
   @override
   Future<Map<String, String>> readAll() async {
-    final data = await _storage.readAll();
+    final data = await _storage.readAll(
+      iOptions: _iosOptions,
+    );
     final sortedData = Map.fromEntries(
       data.entries.toList()..sort((e1, e2) => e1.key.compareTo(e2.key)),
     );
@@ -107,7 +114,7 @@ class SecureKeyValueStorage implements SecureStorage {
     try {
       return await _storage.read(
         key: key,
-        iOptions: iOSTransferToCloud ? null : _iOSDisableCloudStoringOptions,
+        iOptions: _iosOptions,
       );
     } catch (ex, st) {
       onError(ex, st);
@@ -118,7 +125,9 @@ class SecureKeyValueStorage implements SecureStorage {
 
   Future<Map<String, String>> _readAll() async {
     try {
-      return await _storage.readAll();
+      return await _storage.readAll(
+        iOptions: _iosOptions,
+      );
     } catch (ex, st) {
       onError(ex, st);
 
@@ -131,7 +140,7 @@ class SecureKeyValueStorage implements SecureStorage {
       await _storage.write(
         key: key,
         value: value,
-        iOptions: iOSTransferToCloud ? null : _iOSDisableCloudStoringOptions,
+        iOptions: _iosOptions,
       );
     } catch (ex, st) {
       onError(ex, st);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: chili_flutter_storage_impl
 description: Implementation of KeyValueStorage abstract class
-version: 0.0.3
+version: 0.0.4
 publish_to: 'none'
 
 environment:
   sdk: '>=2.19.0 <3.0.0'
 
 dependencies:
-  flutter_secure_storage: ^9.0.0
+  flutter_secure_storage: ^9.2.2
   shared_preferences: ^2.2.3
   chili_flutter_storage:
     git:


### PR DESCRIPTION
If we don't add this option, then with `iOSTransferToCloud: false` param we cannot `readAll()` & `clearAll()` storage also `getKeys()` depends from it